### PR TITLE
Potential fix for code scanning alert no. 12: Incomplete regular expression for hostnames

### DIFF
--- a/handler/youtube.go
+++ b/handler/youtube.go
@@ -22,7 +22,7 @@ var (
 	apiURL = "https://www.googleapis.com/youtube/v3/videos"
 
 	youtubeRegex1 = regexp.MustCompile(`https?://youtu.be/([^\?]+)([\?#]t=.*)?`)
-	youtubeRegex2 = regexp.MustCompile(`https?://.*?youtube.com/watch\?.*?v=([^&#]+)`)
+	youtubeRegex2 = regexp.MustCompile(`https?://.*?youtube\.com/watch\?.*?v=([^&#]+)`)
 )
 
 type YoutubeReply struct {


### PR DESCRIPTION
Potential fix for [https://github.com/lepinkainen/titleparser/security/code-scanning/12](https://github.com/lepinkainen/titleparser/security/code-scanning/12)

To fix the issue, the dot before `com` in the regular expression should be escaped to ensure it matches only a literal dot. This can be done by replacing `.*?youtube.com` with `.*?youtube\.com`. Additionally, using a raw string literal (enclosed in backticks) can improve readability by avoiding the need to double-escape backslashes.

The specific change will be made to the `youtubeRegex2` definition on line 25 in the file `handler/youtube.go`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
