### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete regular expression for hostnames

### DIFF
--- a/handler/hackernews.go
+++ b/handler/hackernews.go
@@ -88,5 +88,5 @@ func HackerNews(url string) (string, error) {
 
 // Register the handler function with corresponding regex
 func init() {
-	lambda.RegisterHandler(".*?news.ycombinator.com.*", HackerNews)
+	lambda.RegisterHandler(".*?news\\.ycombinator\\.com.*", HackerNews)
 }


### PR DESCRIPTION
Potential fix for [https://github.com/lepinkainen/titleparser/security/code-scanning/3](https://github.com/lepinkainen/titleparser/security/code-scanning/3)

To fix the issue, the regular expression `".*?news.ycombinator.com.*"` should be updated to escape the dot (`.`) before `ycombinator.com`. This ensures that the regular expression matches only the intended domain and subdomains of `news.ycombinator.com`. The corrected regular expression should be `".*?news\\.ycombinator\\.com.*"`. Alternatively, a raw string literal can be used to avoid escaping backslashes, e.g., `".*?news\\.ycombinator\\.com.*"`.

The fix involves modifying the `lambda.RegisterHandler` call in `handler/hackernews.go` to use the corrected regular expression.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
