### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete regular expression for hostnames

### DIFF
--- a/handler/imdb.go
+++ b/handler/imdb.go
@@ -94,5 +94,5 @@ func OMDB(url string) (string, error) {
 }
 
 func init() {
-	lambda.RegisterHandler(".*?imdb.com/title/tt.*", OMDB)
+	lambda.RegisterHandler(".*?imdb\\.com/title/tt.*", OMDB)
 }


### PR DESCRIPTION
Potential fix for [https://github.com/lepinkainen/titleparser/security/code-scanning/4](https://github.com/lepinkainen/titleparser/security/code-scanning/4)

To fix the issue, the dot in the regex pattern `".*?imdb.com/title/tt.*"` should be escaped to ensure it matches a literal dot rather than any character. This can be achieved by replacing the dot with `\.`. Additionally, using a raw string literal (enclosed in backticks) for the regex pattern is recommended to avoid the need for double escaping backslashes.

The updated regex pattern will be: `".*?imdb\\.com/title/tt.*"`. This ensures that only URLs with the exact domain "imdb.com" are matched.

The changes will be made in `handler/imdb.go` on line 97.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
