### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete regular expression for hostnames

### DIFF
--- a/handler/pr0gramm.go
+++ b/handler/pr0gramm.go
@@ -9,5 +9,5 @@ func Pr0gramm(url string) (string, error) {
 
 // Register the handler function with corresponding regex
 func init() {
-	lambda.RegisterHandler(".*?pr0gramm.com.*", Pr0gramm)
+	lambda.RegisterHandler(`.*?pr0gramm\.com.*`, Pr0gramm)
 }


### PR DESCRIPTION
Potential fix for [https://github.com/lepinkainen/titleparser/security/code-scanning/5](https://github.com/lepinkainen/titleparser/security/code-scanning/5)

To fix the issue, the regular expression in `handler/pr0gramm.go` should be updated to escape the dot (`.`) before `com`. This ensures that the pattern matches only hostnames containing `pr0gramm.com` and not unintended variations. Additionally, using a raw string literal (`...`) can simplify escaping and improve readability.

**Steps to implement the fix:**
1. Update the regular expression in `handler/pr0gramm.go` on line 12 to escape the dot (`.`) before `com`.
2. Use a raw string literal to avoid the need for double escaping backslashes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
