### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete regular expression for hostnames

### DIFF
--- a/handler/reddit.go
+++ b/handler/reddit.go
@@ -13,7 +13,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var RedditMatch = ".*reddit.com/r/.*/comments/.*/.*"
+var RedditMatch = `.*reddit\.com/r/.*/comments/.*/.*`
 
 type RedditPost []struct {
 	Kind string `json:"kind"`


### PR DESCRIPTION
Potential fix for [https://github.com/lepinkainen/titleparser/security/code-scanning/6](https://github.com/lepinkainen/titleparser/security/code-scanning/6)

To fix the issue, the regular expression in `handler/reddit.go` should be updated to escape the dot before `com`. This ensures that the regular expression matches only valid Reddit URLs and does not allow unintended matches. Specifically:
1. Replace `".*reddit.com/r/.*/comments/.*/.*"` with `".*reddit\\.com/r/.*/comments/.*/.*"`.
2. Use a raw string literal (``` `...` ```) to avoid having to escape backslashes, making the regular expression easier to read and maintain.

The fix involves editing the `RedditMatch` variable in `handler/reddit.go`. No changes are required in `lambda/main.go` because the issue originates from the definition of the regular expression.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
