### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete regular expression for hostnames

### DIFF
--- a/handler/imgur.go
+++ b/handler/imgur.go
@@ -308,7 +308,7 @@ func Imgur(url string) (string, error) {
 // Register the handler function with corresponding regex
 func init() {
 	if os.Getenv("IMGUR_KEY") != "" {
-		lambda.RegisterHandler(".*?imgur.com.*", Imgur)
+		lambda.RegisterHandler(".*?imgur\\.com.*", Imgur)
 	}
 	_ = fmt.Errorf("IMGUR_KEY not set, handler inactive")
 }


### PR DESCRIPTION
Potential fix for [https://github.com/lepinkainen/titleparser/security/code-scanning/7](https://github.com/lepinkainen/titleparser/security/code-scanning/7)

To fix the issue, the regular expression `".*?imgur.com.*"` on line 311 in `handler/imgur.go` should be updated to escape the dot (`.`) before "com". This ensures that the regex matches only the literal string "imgur.com" and not unintended variations. Additionally, using a raw string literal (enclosed in backticks) can improve readability by avoiding the need to double-escape backslashes.

The corrected regex will be: `".*?imgur\\.com.*"` or, as a raw string literal, `".*?imgur\\.com.*"`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
