### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete regular expression for hostnames

### DIFF
--- a/handler/twitter.go
+++ b/handler/twitter.go
@@ -9,5 +9,5 @@ func Twitter(url string) (string, error) {
 
 // Register the handler function with corresponding regex
 func init() {
-	lambda.RegisterHandler(".*?twitter.com.*", Twitter)
+	lambda.RegisterHandler(`.*?twitter\.com.*`, Twitter)
 }


### PR DESCRIPTION
Potential fix for [https://github.com/lepinkainen/titleparser/security/code-scanning/8](https://github.com/lepinkainen/titleparser/security/code-scanning/8)

To fix the issue, the regular expression should be updated to escape the dot (`.`) before `com`. This ensures that the regular expression matches only valid Twitter domains, such as `twitter.com` or subdomains like `www.twitter.com`. Using a raw string literal (`...`) can simplify escaping and improve readability.

**Steps to fix:**
1. Update the regular expression in `handler/twitter.go` to escape the dot (`.`) before `com`.
2. Use a raw string literal to avoid the need for double escaping backslashes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
