### PR TITLE
Potential fix for code scanning alert no. 9: Incomplete regular expression for hostnames

### DIFF
--- a/handler/youtube.go
+++ b/handler/youtube.go
@@ -148,5 +148,5 @@ func Youtube(url string) (string, error) {
 
 func init() {
 	lambda.RegisterHandler(".*youtu.be.*", Youtube)
-	lambda.RegisterHandler(".*youtube.com.*", Youtube)
+	lambda.RegisterHandler(".*youtube\\.com.*", Youtube)
 }


### PR DESCRIPTION
Potential fix for [https://github.com/lepinkainen/titleparser/security/code-scanning/9](https://github.com/lepinkainen/titleparser/security/code-scanning/9)

To fix the issue, the regular expression `".*youtube.com.*"` should be updated to escape the dot (`.`) before "com". This ensures that the regex matches only valid YouTube domains and does not treat the dot as a wildcard character. The corrected regex should be `".*youtube\\.com.*"`. Additionally, using a raw string literal (enclosed in backticks) can improve readability and avoid the need for double escaping.

The changes will be made in the `init` function in `handler/youtube.go`, where the regex is registered with `lambda.RegisterHandler`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
