### PR TITLE
Potential fix for code scanning alert no. 10: Incomplete regular expression for hostnames

### DIFF
--- a/handler/verkkokauppacom.go
+++ b/handler/verkkokauppacom.go
@@ -40,5 +40,5 @@ func Verkkokauppa(url string) (string, error) {
 }
 
 func init() {
-	lambda.RegisterHandler(".*?verkkokauppa.com/.*?/product/*.?", Verkkokauppa)
+	lambda.RegisterHandler(`.*?verkkokauppa\.com/.*?/product/.*?`, Verkkokauppa)
 }


### PR DESCRIPTION
Potential fix for [https://github.com/lepinkainen/titleparser/security/code-scanning/10](https://github.com/lepinkainen/titleparser/security/code-scanning/10)

To fix the issue, the regular expression should be updated to escape the dot before `com` to ensure it matches only the intended hostnames. Specifically:
1. Replace the unescaped dot (`.`) with an escaped dot (`\.`) in the regular expression.
2. Use a raw string literal (`...`) to avoid having to double-escape backslashes, making the regular expression easier to read and maintain.

The fix involves editing the `lambda.RegisterHandler` call in `handler/verkkokauppacom.go` to use the corrected regular expression.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
