### PR TITLE
Potential fix for code scanning alert no. 11: Incomplete regular expression for hostnames

### DIFF
--- a/handler/imgur.go
+++ b/handler/imgur.go
@@ -26,7 +26,7 @@ var (
 
 	// just plain imgur image -> imgur.com/asdf.<any extension> will match
 	// Should handle jpg, gifv etc
-	imageRegex = regexp.MustCompile(`.?imgur\.com/([^\.]+)`)
+	imageRegex = regexp.MustCompile(`\.?imgur\.com/([^\.]+)`)
 )
 
 // ImgurResponse is the imgur generic API response for all gallery queries


### PR DESCRIPTION
Potential fix for [https://github.com/lepinkainen/titleparser/security/code-scanning/11](https://github.com/lepinkainen/titleparser/security/code-scanning/11)

To fix the issue, the unescaped dot (`.`) in the regular expression should be escaped (`\.`) to ensure it matches only a literal dot character. This change will make the regex more precise and prevent unintended matches. Specifically, the regex `.?imgur\.com/([^\.]+)` should be updated to `\.?imgur\.com/([^\.]+)`.

The fix involves editing the definition of `imageRegex` in the file `handler/imgur.go` on line 29. No additional imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
