### PR TITLE
Potential fix for code scanning alert no. 13: Missing regular expression anchor

### DIFF
--- a/handler/imdb.go
+++ b/handler/imdb.go
@@ -19,7 +19,7 @@ var (
 	// TODO: Grab the actual URL query param generation from youtube.go
 	omdbURL = "http://www.omdbapi.com/?i=%s&apikey=%s"
 	// figure out imdb id from url
-	imdbRegex = regexp.MustCompile(`https://www\.imdb\.com/title/(tt[\d]+)`)
+	imdbRegex = regexp.MustCompile(`^https://www\.imdb\.com/title/(tt[\d]+)$`)
 )
 
 type omdbReply struct {


### PR DESCRIPTION
Potential fix for [https://github.com/lepinkainen/titleparser/security/code-scanning/13](https://github.com/lepinkainen/titleparser/security/code-scanning/13)

To fix the issue, we need to add anchors (`^` and `$`) to the regular expression to ensure that it matches only valid IMDb URLs and does not allow arbitrary prefixes or suffixes. Specifically:
- Add `^` at the beginning of the regex to ensure the match starts at the beginning of the string.
- Add `$` at the end of the regex to ensure the match ends at the end of the string.

The updated regex will be `^https://www\.imdb\.com/title/(tt[\d]+)$`. This ensures that only complete and properly formatted IMDb URLs are matched.

The change will be made in the `imdbRegex` variable definition on line 22.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
