### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -3,6 +3,9 @@
 name: Dependabot PR Check
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   check-dependabot:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/lepinkainen/titleparser/security/code-scanning/1](https://github.com/lepinkainen/titleparser/security/code-scanning/1)

To fix the issue, add an explicit `permissions` block to the workflow. Since the workflow is triggered by Dependabot and only echoes a message, it likely requires minimal permissions. The `contents: read` permission is sufficient for this task. This change ensures that the workflow adheres to the principle of least privilege and avoids inheriting potentially excessive permissions from the repository.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
