### PR TITLE
Potential fix for code scanning alert no. 15: Incorrect conversion between integer types

### DIFF
--- a/handler/youtube.go
+++ b/handler/youtube.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -138,7 +139,13 @@ func Youtube(url string) (string, error) {
 	agestr := humanize.RelTime(publishedAt, time.Now(), "ago", "from now")
 
 	viewCount, _ := strconv.ParseInt(video.Statistics.ViewCount, 10, 64)
-	views := HumanizeNumber(int(viewCount))
+	var views string
+	if viewCount >= math.MinInt && viewCount <= math.MaxInt {
+		views = HumanizeNumber(int(viewCount))
+	} else {
+		log.Warnf("View count exceeds int range: %d", viewCount)
+		views = HumanizeNumber(math.MaxInt) // Use max int value as fallback
+	}
 
 	// Ralph Breaks the Internet (2018)
 	title := fmt.Sprintf("%s by %s [%s - %s views - %s%s]", video.Snippet.Title, video.Snippet.ChannelTitle, duration, views, agestr, ageRestricted)


### PR DESCRIPTION
Potential fix for [https://github.com/lepinkainen/titleparser/security/code-scanning/15](https://github.com/lepinkainen/titleparser/security/code-scanning/15)

To fix the issue, we need to ensure that the conversion from `int64` to `int` is safe. This can be achieved by:
1. Adding bounds checks to verify that the parsed `int64` value is within the range of the `int` type before performing the conversion.
2. Alternatively, using a function that directly handles the `int64` type without converting it to `int`.

The best approach is to add bounds checks using constants from the `math` package (`math.MaxInt32` and `math.MinInt32` for 32-bit systems, or `math.MaxInt64` and `math.MinInt64` for 64-bit systems). This ensures portability and correctness.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
