### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Build and Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master]


### PR DESCRIPTION
Potential fix for [https://github.com/lepinkainen/titleparser/security/code-scanning/16](https://github.com/lepinkainen/titleparser/security/code-scanning/16)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the provided steps, the workflow primarily interacts with repository contents (e.g., checking out code, uploading artifacts) and uses a repository token for a specific action. Therefore, we will set `contents: read` and ensure no unnecessary write permissions are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
